### PR TITLE
Increase global test timeout to 20s

### DIFF
--- a/tests/shared/src/test/scala/cats/effect/Runners.scala
+++ b/tests/shared/src/test/scala/cats/effect/Runners.scala
@@ -33,7 +33,7 @@ import scala.reflect.ClassTag
 
 trait Runners extends SpecificationLike with TestInstances with RunnersPlatform { outer =>
 
-  def executionTimeout = 10.seconds
+  def executionTimeout = 20.seconds
 
   def ticked[A: AsResult](test: Ticker => A): Execution =
     Execution.result(test(Ticker(TestContext())))


### PR DESCRIPTION
Closes https://github.com/typelevel/cats-effect/issues/3568